### PR TITLE
Fix Layout to use meta props

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,23 +1,37 @@
 import React from 'react';
+import Head from 'next/head';
 import { motion } from 'framer-motion';
 import Header from './Header';
 import Footer from './Footer';
 
-const Layout: React.FC<{ title: string, description: string, children: React.ReactNode }> = ({ children }) => {
+interface LayoutProps {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ title, description, children }) => {
   return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <motion.main
-        className="flex-grow"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: 20 }}
-        transition={{ duration: 0.3 }}
-      >
-        {children}
-      </motion.main>
-      <Footer />
-    </div>
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <motion.main
+          className="flex-grow"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.3 }}
+        >
+          {children}
+        </motion.main>
+        <Footer />
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- use title and description props in Layout for SEO

## Testing
- `npx tsc` *(fails: Cannot find module 'react' or its corresponding type declarations, etc.)*