### PR TITLE
feat: add blog storage and public pages (ATA-2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ coverage
 .idea
 tsconfig.tsbuildinfo
 README.md
+data

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ coverage/
 .env.test.local
 .env.production.local
 
+# Blog SQLite storage (local dev)
+data/
+
 # Next.js
 .next/
 out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ Components in `src/components/` are split into three categories — keep this se
 
 All content (projects, experience, skills) lives in `src/data/` as TypeScript files. Data is bilingual — keyed by locale (`es`/`en`). Never hardcode content data directly in components.
 
+Blog posts are the one exception: they live in SQLite (`src/server/db.ts`, `src/server/postsRepo.ts`), not `src/data/`, since they're written at runtime rather than committed to git (see `docs/shaping/blog-system.md`, R8). Posts are always in English — `/blog` does not filter by site locale.
+
 ### Localization
 
 - `LanguageContext` in `src/context/LanguageContext.tsx` manages global locale state
@@ -46,6 +48,7 @@ All content (projects, experience, skills) lives in `src/data/` as TypeScript fi
 - `GET /api/csrf` — Returns a CSRF token
 - `POST /api/contact` — Sends email via Mailgun (rate-limited: 3/hour per IP, CSRF required)
 - `POST /api/quote` — Generates project cost estimate using `src/utils/quoteCalculator.ts`
+- `GET /api/blog/[slug]/download` — Serves a post's `content_md` as a downloadable `.md` file
 
 ### Environment Variables
 
@@ -53,6 +56,9 @@ Required in `.env` (see `next.config.js`):
 - `MAILGUN_API_KEY`, `MAILGUN_DOMAIN` — Email sending
 - `CSRF_SECRET` — CSRF token signing
 - `NEXT_PUBLIC_BASE_URL` — Public base URL
+
+Optional:
+- `BLOG_DB_PATH` — Path to the SQLite file backing the blog. Defaults to `./data/blog.db`. In Docker this should stay under `/app/data`, the mount point of the `blog-data` volume in `docker-compose.yml`.
 
 ### Key Rules (from `.cursor/rules/`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,8 @@ services:
       - .env
     ports:
       - "127.0.0.1:3000:3000"
+    volumes:
+      - blog-data:/app/data
+
+volumes:
+  blog-data:

--- a/docs/shaping/blog-system-frame.md
+++ b/docs/shaping/blog-system-frame.md
@@ -1,0 +1,31 @@
+---
+shaping: true
+---
+
+# Sistema de Blog con Ingesta de Notas y Revisión LLM — Frame
+
+## Source
+
+> Creo que me gustaria cambiar esto: mi idea es exportar notas de audio que haga tanto en ingles como en español, desde mi telefono con mi aplicacion de google de recorder (que hace las transcripciones) y que puedo compartirlas o subirlas posteriormente. Creo que lo mejor seria tener una parte donde pueda subir esto, que mediante api de algun LLM lo revise. Quizas ocupar el mismo gemini? no se que sea mas conveniente en este caso, creo que hay que explorarlo.
+>
+> Mi output final de todo es tener un sistema de blog donde la nota la pueda subir, escrita, quede bien formateada, con una revision buena (yo no soy hablante ingles nativo, seria bueno iterar esa parte tambien para tener un buen feedback de la correcion y mejorar mi nivel de ingles) y que esta se suba como una entrada de blog con fecha y en un formato tipo .md para descargar si es necesario.
+>
+> Considerar tambien que estas entradas no son solamente entradas de una conversacion, a veces pueden ser guias, pueden tener referencias a links externos, etc. A veces puede que suba conocimiento mio nada mas.
+
+> **Nota (evolución durante el shaping):** la idea original de grabar con Google Recorder y subir la transcripción se reemplazó por conversar directamente con Claude.ai — ver Shape A en el [shaping doc](./blog-system.md). El Source de arriba se conserva verbatim como registro histórico de la idea inicial.
+
+## Problem
+
+El usuario quiere producir entradas de blog bien formateadas y revisadas a partir de notas propias, conversando directamente con Claude.ai (incluida la app de teléfono). Hoy no tiene una forma de convertir esas conversaciones (u otro texto/conocimiento propio) en entradas de blog publicadas: bien formateadas, revisadas y con fecha.
+
+Como no es hablante nativo de inglés, una corrección silenciosa no es suficiente — necesita entender *qué* se corrigió y *por qué*, para ir mejorando su nivel real de inglés con cada entrada que publica.
+
+Además, el contenido de origen no es homogéneo: a veces nace de una conversación hablada con el asistente, a veces es una guía técnica con referencias a links externos, y a veces es simplemente conocimiento propio escrito directamente.
+
+## Outcome
+
+- Conversa con Claude.ai (vía una Skill dedicada) para redactar y corregir el contenido de una entrada, incluso desde el teléfono.
+- Si el contenido está en inglés, recibe feedback explicativo de las correcciones aplicadas (no solo el texto corregido), como ayuda para mejorar su nivel de inglés.
+- Cuando confirma en el chat, la entrada se publica con fecha en el blog.
+- La entrada queda disponible también como archivo `.md` descargable.
+- El sistema admite distintos tipos de entrada: conversación, guía con referencias externas, o nota de conocimiento propio.

--- a/docs/shaping/blog-system-slices.md
+++ b/docs/shaping/blog-system-slices.md
@@ -1,0 +1,105 @@
+---
+shaping: true
+---
+
+# Sistema de Blog con Ingesta de Notas y Revisión LLM — Slices
+
+Ver [Shaping doc](./blog-system.md) para R, Shape A y el breadboard completo (Detail A). Este documento corta ese breadboard en incrementos verticales, cada uno demo-able.
+
+**Solo planificación — nada de esto está implementado todavía.**
+
+## Slice Summary
+
+| # | Slice | Mechanism (Shape) | Demo |
+|---|-------|--------------------|------|
+| V1 | Almacenamiento + páginas públicas | A4, A5, A6 | Post de prueba insertado a mano aparece en `/blog`, se puede abrir el detalle y descargar el `.md` |
+| V2 | Tool MCP funcionando de punta a punta (auth simple, temporal) | A3, A1 (solo Resource Server) | Un cliente MCP de prueba llama `publish_post` con un token estático; el post nuevo aparece en `/blog` (V1) |
+| V3 | Authorization Server completo (conector real de Claude.ai) | A1 (Authorization Server) | En Claude.ai → Settings → Connectors, se agrega la URL de `/mcp`, se loguea con la contraseña de admin, y el conector queda "Connected" |
+| V4 | Skill de Claude.ai (experiencia conversacional completa) | A2 | Conversación real en Claude.ai (teléfono): compartís la nota, Claude corrige + da feedback de inglés, iterás, confirmás, y la entrada aparece publicada en `/blog` |
+
+El objetivo final (R0) queda demostrado recién al cerrar V4 — cada slice previo es una pieza real y verificable del camino hasta ahí, no trabajo "de relleno".
+
+---
+
+## V1: Almacenamiento + páginas públicas
+
+**Mecanismo:** A4 (SQLite + volume en `docker-compose.yml`), A5 (`/blog`, `/blog/[slug]`), A6 (descarga `.md`).
+
+**Demo:** Se inserta un post de prueba directo en SQLite (script de seed manual). Se visita `/blog`, se ve el listado, se entra al detalle, se ve el Markdown renderizado, y se descarga el `.md`.
+
+| # | Place | Affordance | Control | Wires Out | Returns To |
+|---|-------|------------|---------|-----------|------------|
+| S1 | P3 | `posts` (con fila de prueba insertada a mano) | store | — | — |
+| N20 | P3 | `postsRepo.list(locale?)` | call | reads S1 | → U9 |
+| N21 | P3 | `postsRepo.getBySlug(slug)` | call | reads S1 | → U12 |
+| N22 | P5 | `GET /blog/[slug]/download` | call | reads S1 | → U14 |
+| U8 | P4 | carga de página `/blog` | render | → N20 | — |
+| U9 | P4 | listado de posts (título, fecha, tipo, extracto) | render | — | ← N20 |
+| U10 | P4 | click en tarjeta de post | click | → P5 | — |
+| U11 | P5 | carga de página `/blog/[slug]` | render | → N21 | — |
+| U12 | P5 | contenido renderizado (react-markdown) | render | — | ← N21 |
+| U13 | P5 | botón "Descargar .md" | click | → N22 | — |
+| U14 | P5 | descarga de archivo `.md` en el navegador | render | — | ← N22 |
+
+**Trabajo adicional (no-afordancia):** agregar `volume` en `docker-compose.yml` para persistir el archivo SQLite entre rebuilds (A4.2) — sin esto, V1 se pierde en el primer redeploy.
+
+---
+
+## V2: Tool MCP funcionando de punta a punta (auth simple, temporal)
+
+**Mecanismo:** A3 (acción de publicar) + A1, solo la mitad *Resource Server* (sin el Authorization Server real todavía — se usa un bearer token estático en variable de entorno como placeholder de desarrollo, reemplazado en V3).
+
+**Demo:** Con un cliente MCP de prueba (ej. el MCP Inspector oficial) se llama `publish_post` contra `/mcp` con el token estático de dev. El post nuevo se ve reflejado en `/blog` al recargar (V1).
+
+| # | Place | Affordance | Control | Wires Out | Returns To |
+|---|-------|------------|---------|-----------|------------|
+| N10 | P2 | `/mcp` tool `publish_post()` | call | → N11 | — |
+| N11 | P2 | `verifyBearerToken()` — versión temporal: compara contra un token estático de env var (constant-time). Se reemplaza en V3 por la validación del JWT real emitido por el Authorization Server | call | → N12 (ok) / → error (falla) | — |
+| N12 | P2 | `generateSlug(title, date)` | call | → N13 | — |
+| N13 | P2 | `postsRepo.create()` | write | → S1 | → N14 |
+| N14 | P2 | respuesta de la tool `{slug, publishedAt, mdDownloadUrl}` | return | — | (visto en el cliente MCP de prueba; en V4 esto llega a `U6`) |
+
+**Nota:** este slice de-riesga la parte más nueva del sistema (¿un servidor MCP con Streamable HTTP funciona bien montado sobre el `server.js` Express existente?) antes de invertir en el Authorization Server completo.
+
+---
+
+## V3: Authorization Server completo (conector real de Claude.ai)
+
+**Mecanismo:** A1.3 — reemplaza el token estático de V2 por el flujo OAuth real que Claude.ai espera al agregar un conector personalizado (ver [spike](./spike-mcp-connector-auth.md)).
+
+**Demo:** En Claude.ai → Settings → Connectors → Add custom connector, se pega la URL de `/mcp`. Claude.ai se auto-registra (DCR), redirige a `/authorize`, se ingresa la contraseña de admin, se auto-aprueba, y el conector queda "Connected" en Claude.ai — listo para que V4 lo use.
+
+| # | Place | Affordance | Control | Wires Out | Returns To |
+|---|-------|------------|---------|-----------|------------|
+| P0 | — | Dynamic Client Registration (Claude.ai se auto-registra) | call | → S2 | — |
+| P0 | — | `/authorize` — pide la contraseña de admin, auto-aprueba, redirige con authorization code | call | — | — |
+| P0 | — | `/token` — intercambia code + PKCE por access token (JWT) + refresh token | call | → S3 | — |
+| S2 | P3 | `oauth_clients` (client_id, redirect_uris) | store | — | — |
+| S3 | P3 | `refresh_tokens` | store | — | → N11 (validación/refresh) |
+| N11 | P2 | *(actualizado)* `verifyBearerToken()` ahora valida el JWT real emitido acá, en vez del token estático de V2 | call | → N12 (ok) / → U7 (falla) | — |
+
+**Nota:** este es el slice más nuevo en términos de superficie de riesgo (implementar un Authorization Server, aunque sea mínimo y de un solo usuario) — por eso queda aislado del resto en vez de mezclado con V2.
+
+---
+
+## V4: Skill de Claude.ai (experiencia conversacional completa)
+
+**Mecanismo:** A2 — la Skill que guía la conversación de punta a punta.
+
+**Demo:** Conversación real en Claude.ai, desde el teléfono. Se comparte/dicta el contenido de una nota, Claude (siguiendo la Skill) pregunta el tipo de entrada si falta, corrige y formatea el texto, da feedback explicado si es inglés, permite iterar, y al confirmar llama `publish_post` (ya construido en V2/V3). La entrada aparece publicada en `/blog`.
+
+| # | Place | Affordance | Control | Wires Out | Returns To |
+|---|-------|------------|---------|-----------|------------|
+| U1 | P1 | operador comparte/dicta la nota | type | → N1 | — |
+| N1 | P1 | Skill — clasifica tipo de entrada / idioma (pregunta si falta) | call | → U2 / → N2 | — |
+| U2 | P1 | Claude pregunta tipo/idioma faltante | render | — | ← N1 |
+| N2 | P1 | Skill — corrige y formatea el texto a Markdown | call | → N3 | → U3 |
+| N3 | P1 | Skill — si locale=en, genera feedback explicado de correcciones | call | — | → U3 |
+| U3 | P1 | Claude muestra Markdown corregido + feedback | render | — | ← N2, ← N3 |
+| U4 | P1 | operador pide más cambios (iterar) | type | → N2 | — |
+| U5 | P1 | operador confirma "publicar" | type | → N4 | — |
+| N4 | P1 | Skill — arma parámetros finales y llama la tool | call | → N10 | — |
+| U6 | P1 | Claude confirma publicación (con link) | render | — | ← N14 |
+| U7 | P1 | Claude muestra error si el token del conector es inválido | render | — | ← N11 |
+
+**Nota:** con V4 cerrado, R0 (el objetivo core) queda demostrado de punta a punta por primera vez.

--- a/docs/shaping/blog-system.md
+++ b/docs/shaping/blog-system.md
@@ -1,0 +1,335 @@
+---
+shaping: true
+---
+
+# Sistema de Blog con Ingesta de Notas y Revisión LLM — Shaping
+
+Ver [Frame](./blog-system-frame.md) para Source / Problem / Outcome.
+
+## Requirements (R)
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| R0 | Subir contenido (transcripción de audio o texto propio) y obtener una entrada de blog publicada, con fecha y bien formateada | Core goal |
+| R1 | El sistema acepta contenido de entrada en inglés y en español | Must-have |
+| R2 | **Revisión y corrección vía LLM** | — |
+| R2.1 | El texto subido es corregido/formateado por un LLM antes de publicarse | Must-have |
+| R2.2 | Para contenido en inglés, la revisión incluye feedback explicativo de las correcciones (qué cambió y por qué), no solo el texto corregido | Must-have |
+| R2.3 | Proveedor del LLM a usar | 🟡 Decided: Claude (Anthropic) API |
+| R3 | **Tipos de entrada soportados** | — |
+| R3.1 | 🟡 Contenido originado en una conversación con Claude.ai (dictada o escrita directamente en el chat) | Must-have |
+| R3.2 | Guía técnica con referencias a links externos | Must-have |
+| R3.3 | Nota de conocimiento propio, sin audio de origen | Must-have |
+| R4 | Formato en que llega el contenido a nuestro sistema | 🟡 Decided: el origen (dictado/escrito) ocurre dentro de la conversación de Claude.ai, fuera de nuestro sistema; a nuestro backend solo llega Markdown ya finalizado vía la tool `publish_post` |
+| R5 | La entrada final está disponible como archivo `.md` descargable | Must-have |
+| R6 | Flujo de publicación tras la revisión LLM | 🟡 Decided: revisión manual (el usuario ve texto + feedback, edita y confirma antes de publicar) |
+| R7 | Solo el autor (dueño del sitio) puede subir/crear entradas | Must-have (a confirmar) |
+| R8 | Dónde y en qué formato viven las entradas ya publicadas | 🟡 Decided: storage externo (no archivos .md commiteados a git) |
+| R8.1 | Tecnología concreta de storage | 🟡 Decided: SQLite embebida en el servidor (archivo en disco) |
+
+**Notas:**
+- Todas las decisiones abiertas quedaron resueltas. Falta confirmar el mecanismo concreto de R7 (autenticación de un solo autor) — el proyecto no tiene hoy ningún sistema de login.
+- R8.1 asume que el hosting actual tiene disco persistente entre deploys (coherente con el custom `server.js` + Express, que no es un patrón serverless). Si en algún momento se migra a hosting serverless, esta decisión habría que revisitarla.
+
+---
+
+## A: Ingesta vía Claude.ai (conector MCP + Skill) → confirmación en el chat → SQLite
+
+**Shape final = A3-C + A3 (publicar) + A4 (storage) + A5 (páginas públicas) + A6 (descarga)** — ver exploración de alternativas de canal de interacción más abajo. Sin interfaz gráfica de administración propia y sin panel `curl`: el operador interactúa por chat con Claude.ai (app de escritorio o teléfono), que llama tools sobre un conector MCP propio.
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| **A1** | **Servidor MCP remoto (Resource Server + mini Authorization Server)** | |
+| A1.1 | `/mcp` (Streamable HTTP) expone las tools `publish_post()`, `list_posts()`, `get_post()` | |
+| A1.2 | Resource Server: `requireBearerAuth()` + `verifyAccessToken()` (SDK oficial de MCP) valida el JWT en cada llamada a `/mcp` | |
+| A1.3 | Authorization Server propio: Dynamic Client Registration (Claude.ai se auto-registra) + `/authorize` (auto-aprueba tras validar tu contraseña) + `/token` (emite el JWT) — ver [spike](./spike-mcp-connector-auth.md) | |
+| **A2** | **Skill de Claude.ai** | |
+| A2.1 | Guía la conversación: pregunta el tipo de entrada, corrige/formatea el texto, da feedback de inglés explicado, pide confirmación | |
+| A2.2 | Al confirmar, llama la tool `publish_post` (A1.1) | |
+| **A3** | **Acción de publicar** | |
+| A3.1 | `generateSlug(title, date)` | |
+| A3.2 | Guarda la entrada final en A4 (SQLite) con slug, locale, type, fecha, `content_md` | |
+| **A4** | **Almacenamiento** | |
+| A4.1 | SQLite embebida (archivo en disco del contenedor), tabla `posts` (id, slug, locale, type, title, content_md, created_at) | |
+| A4.2 | Agregar `volume` en `docker-compose.yml` para persistir el archivo entre rebuilds — hoy no hay ninguno definido | |
+| **A5** | **Páginas públicas del blog** | |
+| A5.1 | `/blog` — listado de entradas leyendo desde A4, bilingüe, sigue el patrón `Layout` existente | |
+| A5.2 | `/blog/[slug]` — detalle de una entrada, renderiza el Markdown (react-markdown, ya instalado) | |
+| **A6** | **Descarga `.md`** | |
+| A6.1 | Endpoint que sirve `content_md` de una entrada como archivo descargable | |
+
+No hay un servicio propio de "llamar a la API de Claude para revisar" — la corrección/feedback ocurre nativamente en la conversación de Claude.ai, guiada por la Skill (A2).
+
+## Fit Check: R × A (final)
+
+| Req | Requirement | Status | A |
+|-----|-------------|--------|---|
+| R0 | Subir contenido y obtener una entrada de blog publicada, con fecha y bien formateada | Core goal | ✅ |
+| R1 | Acepta contenido en inglés y español | Must-have | ✅ |
+| R2.1 | Corrección/formateo vía LLM | Must-have | ✅ nativo en la conversación de Claude.ai (A2) |
+| R2.2 | Feedback explicativo de correcciones en inglés | Must-have | ✅ iterativo, en el chat mismo |
+| R2.3 | Proveedor: Claude (Anthropic) | Decided | ✅ |
+| R3.1 | Transcripción de nota de voz / conversación | Must-have | ✅ |
+| R3.2 | Guía técnica con referencias a links externos | Must-have | ✅ |
+| R3.3 | Nota de conocimiento propio, sin audio | Must-have | ✅ |
+| R4 | Solo texto (sin subida/transcripción de audio) | Decided | ✅ |
+| R4.1 | Cómodo desde el teléfono, sin terminal | Must-have | ✅ app de Claude.ai en el teléfono |
+| R5 | Entrada descargable como `.md` | Must-have | ✅ |
+| R6 | Revisión manual antes de publicar | Decided | ✅ confirmás en el chat antes de que la Skill llame `publish_post` |
+| R7 | Solo el autor puede subir/crear entradas | Must-have | ✅ conector vinculado a tu cuenta personal + mini Authorization Server (A1.3) |
+| R8 | Storage externo (no git) | Decided | ✅ |
+| R8.1 | SQLite embebida en el servidor | Decided | ✅ |
+
+**Notas:**
+- Sin flags pendientes. Shape final seleccionado.
+- ⚠️ El **Detail A (breadboard) más abajo todavía describe el diseño anterior** (curl + JWT + `/admin/review` + `/admin/post`), que quedó obsoleto al elegir A3-C. Hay que rehacerlo antes de cortar en slices.
+
+---
+
+## Detail A: Afordancias concretas (Breadboard) — diseño final
+
+El origen del contenido ya no es `curl` — es una conversación real con Claude.ai (Skill-guiada), que puede correr en el teléfono. Las "afordancias UI" del lado Claude.ai son los mensajes del chat (lo que el operador ve y escribe/dicta), aunque vivan fuera de nuestro código. El setup del conector (OAuth) es un flujo aparte, de una sola vez, que se muestra como chunk colapsado.
+
+### Places
+
+| # | Place | Description |
+|---|-------|-------------|
+| P0 | CHUNK: Conector Setup (una vez) | Vincular Claude.ai con nuestro `/mcp` (DCR + OAuth) |
+| P1 | Claude.ai Conversation (Skill-guided) | Donde el operador redacta, itera y confirma |
+| P2 | TRIGGER: MCP Server (Resource Server) | Recibe la tool call `publish_post` |
+| P3 | Backend Storage (SQLite) | Persistencia de `posts` + credenciales del conector |
+| P4 | Public Blog Index (`/blog`) | Listado público de entradas |
+| P5 | Public Blog Detail (`/blog/[slug]`) | Vista de una entrada |
+
+### UI Affordances
+
+| # | Place | Affordance | Control | Wires Out | Returns To |
+|---|-------|------------|---------|-----------|------------|
+| U1 | P1 | mensaje del operador — comparte/dicta el contenido de la nota | type | → N1 | — |
+| U2 | P1 | mensaje de Claude preguntando tipo de entrada / idioma faltante | render | — | ← N1 |
+| U3 | P1 | mensaje de Claude con el Markdown corregido + feedback de inglés (si aplica) | render | — | ← N2, ← N3 |
+| U4 | P1 | operador pide más cambios (iterar) | type | → N2 | — |
+| U5 | P1 | operador confirma "publicar" | type | → N4 | — |
+| U6 | P1 | mensaje de Claude confirmando publicación (con link) | render | — | ← N14 |
+| U7 | P1 | mensaje de Claude con error si el token del conector es inválido | render | — | ← N11 |
+| U8 | P4 | carga de página `/blog` | render | → N20 | — |
+| U9 | P4 | listado de posts (título, fecha, tipo, extracto) | render | — | ← N20 |
+| U10 | P4 | click en tarjeta de post | click | → P5 | — |
+| U11 | P5 | carga de página `/blog/[slug]` | render | → N21 | — |
+| U12 | P5 | contenido renderizado (react-markdown) | render | — | ← N21 |
+| U13 | P5 | botón "Descargar .md" | click | → N22 | — |
+| U14 | P5 | descarga de archivo `.md` en el navegador | render | — | ← N22 |
+
+### Code Affordances
+
+| # | Place | Affordance | Control | Wires Out | Returns To |
+|---|-------|------------|---------|-----------|------------|
+| N1 | P1 | Skill — clasifica tipo de entrada / idioma (pregunta si falta) | call | → U2 / → N2 | — |
+| N2 | P1 | Skill — corrige y formatea el texto a Markdown | call | → N3 | → U3 |
+| N3 | P1 | Skill — si locale=en, genera feedback explicado de correcciones | call | — | → U3 |
+| N4 | P1 | Skill — arma parámetros finales `{content_md, locale, type, date?}` y llama la tool | call | → N10 | — |
+| N10 | P2 | `/mcp` tool `publish_post()` | call | → N11 | — |
+| N11 | P2 | `verifyBearerToken()` — valida el access token emitido en P0 | call | → N12 (ok) / → U7 (falla) | — |
+| N12 | P2 | `generateSlug(title, date)` | call | → N13 | — |
+| N13 | P2 | `postsRepo.create()` | write | → S1 | → N14 |
+| N14 | P2 | respuesta de la tool `{slug, publishedAt, mdDownloadUrl}` | return | — | → U6 |
+| N20 | P3 | `postsRepo.list(locale?)` | call | reads S1 | → U9 |
+| N21 | P3 | `postsRepo.getBySlug(slug)` | call | reads S1 | → U12 |
+| N22 | P5 | `GET /blog/[slug]/download` handler | call | reads S1 | → U14 |
+
+### Data Stores
+
+| # | Place | Store | Description |
+|---|-------|-------|--------------|
+| S1 | P3 | `posts` | id, slug, locale, type, title, content_md, created_at — SQLite en disco (requiere `volume` en `docker-compose.yml`, A4.2) |
+| S2 | P3 | `oauth_clients` | Registrado por DCR (P0) — client_id, redirect_uris |
+| S3 | P3 | `refresh_tokens` | Emitido por `/token` (P0) — permite refrescar/revocar el access token sin repetir `/authorize` |
+
+### P0 (chunk): Conector Setup — detalle
+
+```mermaid
+flowchart TB
+    input([URL de /mcp pegada en Claude.ai Settings])
+    output([access token guardado por Claude.ai])
+
+    subgraph chunk["P0 internals — Authorization Server propio"]
+        A["Dynamic Client Registration — Claude.ai se auto-registra"]
+        B["/authorize — pide tu contraseña de admin"]
+        C["auto-aprueba tras validar, redirige con authorization code"]
+        D["/token — intercambia code + PKCE por access token (JWT) + refresh token"]
+
+        A --> B --> C --> D
+    end
+
+    input --> A
+    D --> output
+
+    classDef boundary fill:#b3e5fc,stroke:#0288d1,stroke-dasharray:5 5
+    class input,output boundary
+```
+
+`A` escribe en **S2** (`oauth_clients`); `D` escribe en **S3** (`refresh_tokens`) y entrega el access token que **N11** valida en cada llamada a `publish_post`.
+
+### Wiring principal (Mermaid)
+
+```mermaid
+flowchart TB
+    P0[["P0: CHUNK — Conector Setup (una vez)"]]
+
+    subgraph P1["P1: Claude.ai Conversation (Skill-guided)"]
+        U1["U1: operador comparte/dicta la nota"]
+        N1["N1: Skill clasifica tipo/idioma"]
+        U2["U2: Claude pregunta si falta info"]
+        N2["N2: Skill corrige y formatea"]
+        N3["N3: Skill feedback de inglés"]
+        U3["U3: Claude muestra Markdown + feedback"]
+        U4["U4: operador pide más cambios"]
+        U5["U5: operador confirma publicar"]
+        N4["N4: Skill arma params y llama tool"]
+        U6["U6: Claude confirma publicación"]
+        U7["U7: Claude muestra error de auth"]
+
+        U1 --> N1
+        N1 -->|falta info| U2
+        N1 -->|completo| N2
+        N2 --> N3
+        N2 -.-> U3
+        N3 -.-> U3
+        U4 --> N2
+        U3 --> U5
+        U5 --> N4
+    end
+
+    subgraph P2["P2: TRIGGER — MCP Server (Resource Server)"]
+        N10["N10: /mcp tool publish_post()"]
+        N11["N11: verifyBearerToken()"]
+        N12["N12: generateSlug()"]
+        N13["N13: postsRepo.create()"]
+        N14["N14: respuesta {slug, publishedAt, mdDownloadUrl}"]
+
+        N10 --> N11
+        N11 -->|ok| N12
+        N12 --> N13
+        N13 -.-> N14
+    end
+
+    N4 --> N10
+    N11 -->|falla| U7
+    N14 -.-> U6
+
+    subgraph P3["P3: Backend Storage (SQLite)"]
+        S1["S1: posts"]
+        S2["S2: oauth_clients"]
+        S3["S3: refresh_tokens"]
+        N20["N20: postsRepo.list()"]
+        N21["N21: postsRepo.getBySlug()"]
+
+        S1 -.-> N20
+        S1 -.-> N21
+    end
+
+    N13 --> S1
+    P0 -.->|escribe| S2
+    P0 -.->|escribe| S3
+    S3 -.->|valida/refresca| N11
+
+    subgraph P4["P4: Public Blog Index (/blog)"]
+        U8["U8: carga /blog"]
+        U9["U9: listado de posts"]
+        U10["U10: click en post"]
+
+        U8 --> N20
+        N20 -.-> U9
+        U9 --> U10
+    end
+
+    U10 --> P5
+
+    subgraph P5["P5: Public Blog Detail (/blog/[slug])"]
+        U11["U11: carga /blog/[slug]"]
+        U12["U12: contenido renderizado"]
+        U13["U13: botón Descargar .md"]
+        U14["U14: descarga .md"]
+        N22["N22: GET /blog/[slug]/download"]
+
+        U11 --> N21
+        N21 -.-> U12
+        U13 --> N22
+        N22 -.-> U14
+    end
+
+    N22 --> S1
+
+    classDef ui fill:#ffb6c1,stroke:#d87093,color:#000
+    classDef nonui fill:#d3d3d3,stroke:#808080,color:#000
+    classDef store fill:#e6e6fa,stroke:#9370db,color:#000
+    classDef chunk fill:#b3e5fc,stroke:#0288d1,color:#000,stroke-width:2px
+
+    class U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14 ui
+    class N1,N2,N3,N4,N10,N11,N12,N13,N14,N20,N21,N22 nonui
+    class S1,S2,S3 store
+    class P0 chunk
+```
+
+**Notas:**
+- `corrections` (feedback de inglés) se genera y se muestra en `U3`, pero no se persiste en `S1` — sigue pendiente confirmar si conviene guardarlo para un historial de aprendizaje.
+- Sigue pendiente decidir si `/blog` (`U9`) filtra por el locale activo del sitio o muestra todo sin filtrar.
+- A4.2 (`volume` en `docker-compose.yml`) es config de despliegue — se anota junto a `S1`/`S2`/`S3` porque es lo que los hace persistentes entre rebuilds.
+- El loop de iteración (`U4` → `N2`) es deliberadamente simple: cada vuelta reemplaza el Markdown mostrado en `U3`, no acumulamos historial de versiones.
+
+---
+
+## R9 (nuevo, extiende R4): Comodidad de interacción desde el teléfono
+
+| ID | Requirement | Status |
+|----|-------------|--------|
+| R4.1 | La interacción para subir/revisar debe ser cómoda desde el teléfono, inmediatamente después de grabar la nota (no requiere terminal/SSH) | 🟡 Nuevo — Must-have |
+
+## A3: Canal de interacción del operador — explorando alternativas
+
+Esto reemplaza/redefine A1 (auth) + A2 (servicio de revisión) + A3 (endpoints) juntos, según la alternativa elegida.
+
+### A3-A: curl directo (diseño original)
+
+| Part | Mechanism |
+|------|-----------|
+| A3-A.1 | JWT de corta duración vía `/admin/login` (A1 original) |
+| A3-A.2 | Claude API llamada server-side (A2 original) |
+| A3-A.3 | `/admin/review` (una pasada, JSON) + `/admin/post` |
+| A3-A.4 | Para iterar, el usuario vuelve a llamar `/admin/review` a mano con el texto editado |
+
+### A3-B: Bot de Telegram
+
+| Part | Mechanism |
+|------|-----------|
+| A3-B.1 | Bot registrado vía BotFather, token en env var |
+| A3-B.2 | `POST /admin/telegram/webhook` — recibe mensajes; solo responde al `chat_id` del autor (whitelist) |
+| A3-B.3 | Al recibir texto, llama a Claude API server-side (A2 original) y responde en el chat con Markdown + feedback |
+| A3-B.4 | El usuario puede seguir chateando para iterar (el bot mantiene el historial de la conversación y vuelve a llamar a Claude) |
+| A3-B.5 | Comando/botón inline "Publicar" → dispara A4 (guardar en SQLite) |
+
+### A3-C: Conector MCP remoto para Claude.ai
+
+| Part | Mechanism | Flag |
+|------|-----------|:----:|
+| A3-C.1 | Servidor MCP remoto (Streamable HTTP) expone tools: `publish_post()`, `list_posts()`, `get_post()` | |
+| A3-C.2 | Autenticación del conector: mini Authorization Server propio (DCR + `/authorize` con auto-aprobación por contraseña + `/token` que emite JWT) + Resource Server en `/mcp` (resuelto casi entero por el SDK oficial de MCP vía `requireBearerAuth`). Ver [spike](./spike-mcp-connector-auth.md) | |
+| A3-C.3 | La revisión/corrección/feedback ocurre en la conversación nativa con Claude.ai — no hace falta llamar a la API de Claude por separado (A2 deja de existir como servicio) | |
+| A3-C.4 | Cuando el usuario pide publicar, Claude llama la tool `publish_post` → dispara A4 | |
+| A3-C.5 | Skill de Claude.ai (subida a tu cuenta, no vive en este repo salvo copia versionada en `docs/`) que guía la conversación: pregunta el tipo de entrada, corrige/formatea, da feedback de inglés explicado, pide confirmación y recién ahí llama `publish_post` | |
+
+### Fit Check: R × A3 alternativas (final)
+
+| Req | Requirement | Status | A3-A | A3-B | A3-C |
+|-----|-------------|--------|------|------|------|
+| R2.2 | Feedback explicado en inglés, iterativo | Must-have | ✅ (no iterativo, una pasada) | ✅ | ✅ |
+| R4.1 | Cómodo desde el teléfono, sin terminal | Must-have | ❌ | ✅ | ✅ |
+| R6 | Revisión manual antes de publicar | Decided | ✅ | ✅ | ✅ |
+| R7 | Solo el autor puede publicar | Must-have | ✅ (JWT) | ✅ (whitelist chat_id) | ✅ (cuenta personal + auth conector) |
+
+**Notas:**
+- A3-A falla R4.1: correr `curl` desde el teléfono es incómodo (aunque sea técnicamente posible con apps tipo Termux).
+- A3-C y A3-B quedan empatadas en el fit check formal — la diferencia está fuera de la tabla: A3-C reusa Claude.ai mismo como interfaz conversacional (nada de loop de chat propio que mantener) y suma la Skill (A2) como capa de guion versionable, a cambio de construir un mini Authorization Server (ya des-flagged por el [spike](./spike-mcp-connector-auth.md)). A3-B evita el Authorization Server pero exige mantener nuestro propio loop de conversación en el bot.
+- A3-A queda descartada (falla R4.1) y A3-B descartada (se prefiere la interfaz nativa de Claude.ai). Se conservan acá como registro de las alternativas evaluadas.
+
+**Selección: A3-C.** Sin flags pendientes — ver Shape A final arriba.

--- a/docs/shaping/spike-mcp-connector-auth.md
+++ b/docs/shaping/spike-mcp-connector-auth.md
@@ -1,0 +1,41 @@
+## A3-C Spike: Auth de conector MCP remoto para Claude.ai
+
+### Context
+
+Se eligió A3-C (conector MCP remoto) como canal de interacción para el sistema de blog: en vez de curl o un bot de Telegram, el operador chatea directo con Claude.ai (Pro/Max/Team/Enterprise), y Claude llama tools (`publish_post`, `list_posts`, `get_post`) expuestas por un servidor MCP remoto que corre junto al sitio. El único part flagged en el shape es A3-C.2: el mecanismo de autenticación del conector — no sabíamos si es OAuth completo o un header auth simple en beta (que requiere acceso anticipado de Anthropic, no garantizado).
+
+### Goal
+
+Saber concretamente qué hay que implementar en `atariki-site` para que Claude.ai pueda conectarse de forma segura a un servidor MCP remoto propio, y con qué esfuerzo/mecanismo — para decidir si seguimos con A3-C tal cual o ajustamos el shape.
+
+### Questions
+
+| # | Question |
+|---|----------|
+| **Q1** | ¿Qué endpoints/mecanismos concretos exige el spec de MCP para que un servidor remoto soporte auth vía OAuth (discovery, authorization, token, registro de cliente)? |
+| **Q2** | ¿Qué provee el SDK oficial de MCP (TypeScript) ya resuelto vs. qué queda por implementar a mano nosotros? |
+| **Q3** | ¿El header auth en beta es realmente inaccesible sin contactar a Anthropic, o hay alguna vía self-serve? |
+| **Q4** | ¿Dónde encaja el servidor MCP en la arquitectura actual (`server.js` con Express + Next.js) — mismo proceso, misma ruta base, o servicio aparte? |
+| **Q5** | ¿Qué transporte hay que usar hoy (Streamable HTTP vs SSE) y qué implica para nuestro servidor Express existente? |
+
+### Acceptance
+
+El spike está completo cuando podemos describir, con referencias concretas a la documentación oficial, los pasos exactos para implementar auth en un servidor MCP remoto en este proyecto (qué endpoints, qué librería, qué queda a mano), y si el header auth beta es una opción realista hoy o no.
+
+### Findings
+
+**Q1 — Qué exige el spec:** Un servidor MCP remoto con auth necesita, del lado *Resource Server*: metadata de RFC 9728 (protected resource) y RFC 8414 (authorization server, aunque sea espejada). Del lado *Authorization Server* (que Claude.ai como cliente MCP espera encontrar): Dynamic Client Registration (RFC 7591 — Claude.ai se auto-registra como client la primera vez que agregás el conector), endpoint `/authorize` (authorization_code + PKCE), endpoint `/token`.
+
+**Q2 — Qué da el SDK oficial (`@modelcontextprotocol/typescript-sdk`) vs. qué queda a mano:**
+- ✅ **Resource Server (lado `/mcp`):** completamente resuelto — `requireBearerAuth()` + una función `verifyAccessToken(token)` que escribimos nosotros (puede ser tan simple como verificar un JWT propio), más helpers para publicar la metadata (`mcpAuthMetadataRouter`, `getOAuthProtectedResourceMetadataUrl`).
+- ❌ **Authorization Server (DCR + `/authorize` + `/token` + discovery):** **no viene como librería lista para producción.** El repo del SDK trae solo *ejemplos de referencia* (`examples/oauth/` — flujo `authorization_code` completo con auto-consent; `examples/oauth-client-credentials/` — AS mínimo solo para `client_credentials`). La docs lo dice explícito: *"The SDK itself does not issue tokens."* Hay que adaptar uno de esos ejemplos a mano.
+
+**Q3 — Header auth beta:** Confirmado por búsqueda previa — el rollout es gradual y el acceso temprano requiere contactar a Anthropic directamente. No es self-serve hoy. No podemos depender de esta vía.
+
+**Q4 — Dónde encaja en `atariki-site`:** Todo puede vivir como rutas Express adicionales dentro del mismo `server.js` (mismo proceso): `/mcp` (Resource Server), `/oauth/authorize`, `/oauth/token`, `/oauth/register` (DCR), `/.well-known/oauth-authorization-server`. No hace falta un servicio aparte.
+
+**Q5 — Transporte:** Streamable HTTP (SSE está deprecado desde el spec de marzo 2025). El SDK monta esto directo sobre una ruta Express (`createMcpExpressApp` / `toNodeHandler`), compatible con el server actual.
+
+### Conclusión
+
+A3-C.2 deja de ser un unknown — ya sabemos *qué* hay que construir: un mini Authorization Server de un solo usuario (DCR + `/authorize` con auto-aprobación tras validar tu contraseña, reusando la idea original de login + `/token` que emite un JWT firmado) **además** del Resource Server (que el SDK resuelve casi entero). Es más trabajo que un JWT simple tipo curl, pero es acotado y con ejemplos oficiales para adaptar — no es una apuesta a ciegas.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "export": "next export"
+    "export": "next export",
+    "seed:post": "node scripts/seed-post.js"
   },
   "keywords": [
     "desarrollador",

--- a/scripts/seed-post.js
+++ b/scripts/seed-post.js
@@ -1,0 +1,67 @@
+require('dotenv').config();
+
+const { DatabaseSync } = require('node:sqlite');
+const fs = require('fs');
+const path = require('path');
+
+const dbPath = process.env.BLOG_DB_PATH
+  ? path.resolve(process.env.BLOG_DB_PATH)
+  : path.join(process.cwd(), 'data', 'blog.db');
+
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+const db = new DatabaseSync(dbPath);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS posts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT NOT NULL UNIQUE,
+    locale TEXT NOT NULL,
+    type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content_md TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  )
+`);
+
+const testPost = {
+  slug: 'hello-world',
+  locale: 'en',
+  type: 'note',
+  title: 'Hello, World',
+  content_md: [
+    '# Hello, World',
+    '',
+    'This is a test post inserted by `scripts/seed-post.js` to validate the V1 storage slice: SQLite persistence, the `/blog` listing, the `/blog/[slug]` detail view, and the `.md` download endpoint.',
+    '',
+    '## What this proves',
+    '',
+    '- Posts persist in SQLite across container rebuilds (via the `blog-data` volume).',
+    '- `postsRepo.list()` and `postsRepo.getBySlug()` read correctly.',
+    '- Markdown renders through `react-markdown` on the detail page.',
+    '- The `.md` file downloads with the original content intact.',
+  ].join('\n'),
+  created_at: new Date().toISOString(),
+};
+
+const insert = db.prepare(`
+  INSERT OR IGNORE INTO posts (slug, locale, type, title, content_md, created_at)
+  VALUES (?, ?, ?, ?, ?, ?)
+`);
+
+const result = insert.run(
+  testPost.slug,
+  testPost.locale,
+  testPost.type,
+  testPost.title,
+  testPost.content_md,
+  testPost.created_at
+);
+
+if (result.changes > 0) {
+  console.log(`Seeded test post "${testPost.slug}" at ${dbPath}`);
+} else {
+  console.log(`Post "${testPost.slug}" already exists at ${dbPath}, skipped.`);
+}
+
+db.close();

--- a/src/components/logical/BlogListSection.tsx
+++ b/src/components/logical/BlogListSection.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import BlogPostCard from '../ui/BlogPostCard';
+import { useLanguage } from '../../context/LanguageContext';
+import type { PostData } from '../../types/post';
+
+interface BlogListSectionProps {
+  posts: PostData[];
+  title: string;
+  description: string;
+}
+
+const BlogListSection: React.FC<BlogListSectionProps> = ({ posts, title, description }) => {
+  const { locale } = useLanguage();
+  const isSpanish = locale === 'es';
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      className="max-w-7xl mx-auto"
+    >
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold text-term-text mb-2">{title}</h1>
+        <p className="text-term-sub text-[15px]">{description}</p>
+      </div>
+
+      {posts.length === 0 ? (
+        <div className="text-center py-12">
+          <div className="text-term-muted text-base">
+            {isSpanish ? 'Todavía no hay entradas publicadas' : 'No entries published yet'}
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {posts.map((post, index) => (
+            <BlogPostCard key={post.id} post={post} index={index} />
+          ))}
+        </div>
+      )}
+    </motion.section>
+  );
+};
+
+export default BlogListSection;

--- a/src/components/ui/BlogPostCard.tsx
+++ b/src/components/ui/BlogPostCard.tsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from 'react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { useLanguage } from '../../context/LanguageContext';
+import { getExcerpt } from '../../utils/blog';
+import type { PostData, PostType } from '../../types/post';
+
+interface BlogPostCardProps {
+  post: PostData;
+  index: number;
+}
+
+const TYPE_ACCENT: Record<PostType, string> = {
+  conversation: '#5b93ff',
+  guide: '#4ade80',
+  note: '#fbbf24',
+};
+
+const TYPE_LABEL_ES: Record<PostType, string> = {
+  conversation: 'Conversación',
+  guide: 'Guía',
+  note: 'Nota',
+};
+
+const TYPE_LABEL_EN: Record<PostType, string> = {
+  conversation: 'Conversation',
+  guide: 'Guide',
+  note: 'Note',
+};
+
+const BlogPostCard: React.FC<BlogPostCardProps> = ({ post, index }) => {
+  const { locale } = useLanguage();
+  const isSpanish = locale === 'es';
+
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(isSpanish ? 'es-CL' : 'en-US', { day: 'numeric', month: 'short', year: 'numeric' }),
+    [isSpanish]
+  );
+
+  const typeLabel = (isSpanish ? TYPE_LABEL_ES : TYPE_LABEL_EN)[post.type];
+  const typeAccent = TYPE_ACCENT[post.type];
+  const excerpt = useMemo(() => getExcerpt(post.content_md), [post.content_md]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: index * 0.1 }}
+    >
+      <Link
+        href={`/blog/${post.slug}`}
+        className="block bg-term-panel border border-term-border rounded-2xl p-[22px] hover:border-term-blue transition-colors duration-200"
+      >
+        <div className="flex items-center gap-1.5 mb-2.5">
+          <span className="w-[5px] h-[5px] rounded-full" style={{ background: typeAccent }} />
+          <span className="text-xs" style={{ color: typeAccent }}>
+            {typeLabel}
+          </span>
+          <span className="text-term-dim text-xs">·</span>
+          <span className="text-term-dim text-xs">{dateFormatter.format(new Date(post.created_at))}</span>
+        </div>
+        <h3 className="text-[17px] font-bold text-term-text mb-2">{post.title}</h3>
+        <p className="text-term-sub text-[13.5px] leading-relaxed">{excerpt}</p>
+      </Link>
+    </motion.div>
+  );
+};
+
+export default BlogPostCard;

--- a/src/pages/api/blog/[slug]/download.ts
+++ b/src/pages/api/blog/[slug]/download.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import postsRepo from '../../../../server/postsRepo';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const { slug } = req.query;
+  if (typeof slug !== 'string') {
+    return res.status(400).json({ message: 'Invalid slug' });
+  }
+
+  const post = postsRepo.getBySlug(slug);
+  if (!post) {
+    return res.status(404).json({ message: 'Post not found' });
+  }
+
+  res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${post.slug}.md"`);
+  res.status(200).send(post.content_md);
+}

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import type { GetServerSideProps } from 'next';
+import Markdown from 'react-markdown';
+import Layout from '../../components/functional/Layout';
+import { useLanguage } from '../../context/LanguageContext';
+import postsRepo from '../../server/postsRepo';
+import type { PostData } from '../../types/post';
+
+interface BlogPostPageProps {
+  post: PostData;
+}
+
+const BlogPostPage: React.FC<BlogPostPageProps> = ({ post }) => {
+  const { locale } = useLanguage();
+  const isSpanish = locale === 'es';
+
+  const dateFormatter = new Intl.DateTimeFormat(isSpanish ? 'es-CL' : 'en-US', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const copy = isSpanish ? { download: 'Descargar .md' } : { download: 'Download .md' };
+
+  return (
+    <Layout title={`${post.title} - Ariel Lobos Haoa`} description={post.title} canonicalUrl={`/blog/${post.slug}`}>
+      <div className="min-h-screen flex flex-col bg-transparent text-term-text">
+        <main className="flex-1 max-w-[820px] w-full mx-auto px-6 py-14">
+          <article>
+            <div className="mb-8">
+              <span className="text-term-dim text-xs">{dateFormatter.format(new Date(post.created_at))}</span>
+              <h1 className="text-3xl font-bold text-term-text mt-2 mb-4">{post.title}</h1>
+              <a
+                href={`/api/blog/${post.slug}/download`}
+                className="inline-flex items-center gap-1.5 px-4 py-2 bg-term-panelAlt text-term-sub rounded-lg text-[12.5px] hover:text-term-text transition-colors duration-200"
+              >
+                {copy.download}
+              </a>
+            </div>
+
+            <div className="space-y-4">
+              <Markdown
+                components={{
+                  h1: ({ node, ...rest }) => <h2 className="text-2xl font-bold text-term-text mt-8 mb-3" {...rest} />,
+                  h2: ({ node, ...rest }) => <h3 className="text-xl font-bold text-term-text mt-8 mb-3" {...rest} />,
+                  h3: ({ node, ...rest }) => <h4 className="text-lg font-bold text-term-text mt-6 mb-2" {...rest} />,
+                  p: ({ node, ...rest }) => <p className="text-term-sub text-[15px] leading-relaxed mb-4" {...rest} />,
+                  a: ({ node, ...rest }) => (
+                    <a className="text-term-blue hover:text-term-blueHover underline" target="_blank" rel="noopener noreferrer" {...rest} />
+                  ),
+                  ul: ({ node, ...rest }) => <ul className="list-disc list-inside text-term-sub text-[15px] mb-4 space-y-1" {...rest} />,
+                  ol: ({ node, ...rest }) => <ol className="list-decimal list-inside text-term-sub text-[15px] mb-4 space-y-1" {...rest} />,
+                  li: ({ node, ...rest }) => <li className="text-term-sub" {...rest} />,
+                  code: ({ node, className, ...rest }) => (
+                    <code className={`bg-term-panelAlt text-term-amber px-1.5 py-0.5 rounded text-[13px] ${className ?? ''}`.trim()} {...rest} />
+                  ),
+                  pre: ({ node, ...rest }) => (
+                    <pre className="bg-term-panelAlt border border-term-border rounded-lg p-4 overflow-x-auto mb-4 text-[13px]" {...rest} />
+                  ),
+                  blockquote: ({ node, ...rest }) => (
+                    <blockquote className="border-l-2 border-term-border pl-4 text-term-muted italic mb-4" {...rest} />
+                  ),
+                }}
+              >
+                {post.content_md}
+              </Markdown>
+            </div>
+          </article>
+        </main>
+      </div>
+    </Layout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async ({ params }) => {
+  const slug = params?.slug;
+  if (typeof slug !== 'string') {
+    return { notFound: true };
+  }
+
+  const post = postsRepo.getBySlug(slug);
+  if (!post) {
+    return { notFound: true };
+  }
+
+  return { props: { post } };
+};
+
+export default BlogPostPage;

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react';
+import type { GetServerSideProps } from 'next';
+import Layout from '../../components/functional/Layout';
+import BlogListSection from '../../components/logical/BlogListSection';
+import { useLanguage } from '../../context/LanguageContext';
+import postsRepo from '../../server/postsRepo';
+import type { PostData } from '../../types/post';
+
+interface BlogPageProps {
+  posts: PostData[];
+}
+
+const BlogPage: React.FC<BlogPageProps> = ({ posts }) => {
+  const { locale } = useLanguage();
+  const isSpanish = locale === 'es';
+
+  const seoCopy = useMemo(
+    () =>
+      isSpanish
+        ? {
+            title: 'Blog - Ariel Lobos Haoa',
+            description: 'Notas técnicas y aprendizajes de Ariel Lobos Haoa.',
+            keywords: 'blog, notas técnicas, desarrollo de software, Ariel Lobos Haoa',
+            sectionTitle: 'Blog',
+            sectionDescription: 'Notas técnicas, guías y aprendizajes, publicados en inglés.',
+          }
+        : {
+            title: 'Blog - Ariel Lobos Haoa',
+            description: 'Technical notes and learnings from Ariel Lobos Haoa.',
+            keywords: 'blog, technical notes, software development, Ariel Lobos Haoa',
+            sectionTitle: 'Blog',
+            sectionDescription: 'Technical notes, guides, and learnings.',
+          },
+    [isSpanish]
+  );
+
+  return (
+    <Layout title={seoCopy.title} description={seoCopy.description} canonicalUrl="/blog" keywords={seoCopy.keywords}>
+      <div className="min-h-screen flex flex-col bg-transparent text-term-text">
+        <main className="flex-1 max-w-[1180px] w-full mx-auto px-6 py-14">
+          <BlogListSection posts={posts} title={seoCopy.sectionTitle} description={seoCopy.sectionDescription} />
+        </main>
+      </div>
+    </Layout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<BlogPageProps> = async () => {
+  const posts = postsRepo.list();
+  return { props: { posts } };
+};
+
+export default BlogPage;

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,0 +1,40 @@
+import { DatabaseSync } from 'node:sqlite';
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_DB_PATH = path.join(process.cwd(), 'data', 'blog.db');
+
+function createDatabase(): DatabaseSync {
+  const dbPath = process.env.BLOG_DB_PATH ? path.resolve(process.env.BLOG_DB_PATH) : DEFAULT_DB_PATH;
+
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  const database = new DatabaseSync(dbPath);
+
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      slug TEXT NOT NULL UNIQUE,
+      locale TEXT NOT NULL,
+      type TEXT NOT NULL,
+      title TEXT NOT NULL,
+      content_md TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    )
+  `);
+
+  return database;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __blogDb: DatabaseSync | undefined;
+}
+
+const db = global.__blogDb ?? createDatabase();
+
+if (process.env.NODE_ENV !== 'production') {
+  global.__blogDb = db;
+}
+
+export default db;

--- a/src/server/postsRepo.ts
+++ b/src/server/postsRepo.ts
@@ -1,0 +1,16 @@
+import db from './db';
+import type { PostData } from '../types/post';
+
+const listStatement = db.prepare('SELECT * FROM posts ORDER BY created_at DESC');
+const getBySlugStatement = db.prepare('SELECT * FROM posts WHERE slug = ?');
+
+function list(): PostData[] {
+  return listStatement.all() as unknown as PostData[];
+}
+
+function getBySlug(slug: string): PostData | null {
+  const row = getBySlugStatement.get(slug);
+  return (row as unknown as PostData) ?? null;
+}
+
+export default { list, getBySlug };

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,13 @@
+import type { Locale } from './locale';
+
+export type PostType = 'conversation' | 'guide' | 'note';
+
+export interface PostData {
+  id: number;
+  slug: string;
+  locale: Locale;
+  type: PostType;
+  title: string;
+  content_md: string;
+  created_at: string;
+}

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,0 +1,24 @@
+export function getExcerpt(markdown: string, length = 160): string {
+  const withoutLeadingHeading = markdown.replace(/^\s*#{1,6}[^\n]*\n+/, '');
+
+  const plainText = withoutLeadingHeading
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^>\s?/gm, '')
+    .replace(/^[-*+]\s+/gm, '')
+    .replace(/~~([^~]*)~~/g, '$1')
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (plainText.length <= length) {
+    return plainText;
+  }
+
+  const truncated = plainText.slice(0, length);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${truncated.slice(0, lastSpace > 0 ? lastSpace : length)}…`;
+}


### PR DESCRIPTION
Implements V1 of the shaped blog system: SQLite persistence via node:sqlite (no native deps), the /blog and /blog/[slug] public pages, and the .md download endpoint. Includes the shaping docs the slice was cut from and a seed script to insert a test post by hand.