### PR TITLE
fix: pin prod deploy job to the production runner label

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, production]
     steps:
       - name: Sync repository
         run: |


### PR DESCRIPTION
## Summary
- El job `deploy` de `.github/workflows/deploy.yml` usaba `runs-on: self-hosted`, que matchea cualquier runner self-hosted del repo.
- Con el nuevo host de staging (`atariki-optiplex`, labels `self-hosted, Linux, X64, staging`) sumado junto a `raspberry-a` (labels `self-hosted, Linux, ARM64`), el job de prod podía caer en cualquiera de los dos.
- En el último push a `master`, cayó en `atariki-optiplex`, que no tiene `/home/atariki/atariki-site` (solo `atariki-site-staging`), y el step "Sync repository" falló con `No such file or directory`.
- Se agregó la label custom `production` al runner `raspberry-a` (vía API) y se ancló el job a `[self-hosted, production]`, simétrico a como `deploy-staging.yml` ya usa la label `staging`.

## Test plan
- [ ] Mergear a `dev` y luego promover a `master` para confirmar que el deploy corre en `raspberry-a` y no en `atariki-optiplex`.
- [ ] Verificar en los logs del run (`runner_name`) que fue `raspberry-a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bi2uMoNtQUNTjTrbn5Bdos