### PR TITLE
fix: pass --remove-orphans on deploy so stale containers don't hold ports

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build and deploy
         run: |
           cd /home/atariki/atariki-site-staging
-          docker compose -f docker-compose.staging.yml up -d --build
+          docker compose -f docker-compose.staging.yml up -d --build --remove-orphans
 
       - name: Health check
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build and deploy
         run: |
           cd /home/atariki/atariki-site
-          docker compose up -d --build
+          docker compose up -d --build --remove-orphans
 
       - name: Health check
         run: |


### PR DESCRIPTION
## Summary
- El último deploy a prod falló: `docker compose up -d --build` no pudo levantar `atariki-site-frontend` porque un contenedor huérfano `atariki-site` (servicio `web` del `docker-compose.yml` viejo, de antes del split frontend/backend) seguía corriendo y ocupando `127.0.0.1:3000`.
- `docker compose up` no borra contenedores de servicios que ya no están en el compose file salvo que se le pida con `--remove-orphans`.
- Se agregó `--remove-orphans` al build/deploy step de `deploy.yml` (prod) y `deploy-staging.yml` (staging, preventivo, mismo tipo de problema podría repetirse ante un futuro cambio del compose file).

## Ya resuelto manualmente
El contenedor huérfano se bajó a mano en `raspberry-a` para restablecer el sitio (ahora sirviendo el código nuevo, confirmado con curl). Este PR es para que el próximo deploy no dependa de intervención manual.

## Test plan
- [ ] Mergear a `dev` y confirmar que el deploy de staging corre sin warnings de orphan containers.
- [ ] Promover a `master` y confirmar el mismo comportamiento en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bi2uMoNtQUNTjTrbn5Bdos